### PR TITLE
Create doc.go to enable package without CGO

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,1 @@
+package pointer


### PR DESCRIPTION
This is needed because without it packages that depend on it break without having CGO enabled with:

build constraints exclude all Go files in go/src/github.com/mattn/go-pointer